### PR TITLE
Dead lock bug fixed and adjust max limit of request body

### DIFF
--- a/etc/conf/app.conf
+++ b/etc/conf/app.conf
@@ -36,7 +36,7 @@ auto_sync_interval = 30
 read_timeout = 5s
 write_timeout = 5s
 max_header_bytes = 16384
-max_body_bytes = 10240
+max_body_bytes = 65536
 
 quota_manage_ip = ""
 #suppot buildin, fusionstage, unlimit

--- a/server/service/microservices.go
+++ b/server/service/microservices.go
@@ -214,12 +214,14 @@ func (s *ServiceController) Create(ctx context.Context, in *pb.CreateServiceRequ
 	ok, err := quota.QuotaPlugins[beego.AppConfig.DefaultString("quota_plugin", "buildin")]().Apply4Quotas(ctx, quota.MicroServiceQuotaType, 0)
 	if err != nil {
 		util.LOGGER.Errorf(err, "create microservice failed, %s: check apply quota.operator:%s", serviceFlag, remoteIP)
+		lock.Unlock()
 		return &pb.CreateServiceResponse{
 			Response: pb.CreateResponse(pb.Response_FAIL, err.Error()),
 		}, err
 	}
 	if !ok {
 		util.LOGGER.Errorf(err, "create microservice failed, %s: no quota to apply.operator:%s", serviceFlag, remoteIP)
+		lock.Unlock()
 		return &pb.CreateServiceResponse{
 			Response: pb.CreateResponse(pb.Response_FAIL, fmt.Sprintf("No quota to create service,service name is %s", in.Service.ServiceName)),
 		}, nil


### PR DESCRIPTION
1. Fix dead lock bug when call quota api failed.
2. Adjust max bytes limit of request body