### PR TITLE
Support docker-compose for building the project

### DIFF
--- a/scripts/docker/build-image/Dockerfile.tmpl
+++ b/scripts/docker/build-image/Dockerfile.tmpl
@@ -1,0 +1,6 @@
+FROM {{.BASE_IMAGE}}:{{.BASE_IMAGE_VERSION}}
+
+COPY ./service-center ./start.sh /root/
+
+ENTRYPOINT ["/root/start.sh"]
+

--- a/scripts/docker/build-image/README.md
+++ b/scripts/docker/build-image/README.md
@@ -1,0 +1,16 @@
+## Service-Center support for build docker image
+
+This script helps you to make the docker image of service-center present in your current working directory.
+
+Here quay.io/coreos/etcd:v3.1.0 used as etcd base image. start.sh will be the entrypoint for the docker container to start.
+
+### How To Run
+
+This script assumes you have already downloaded all the dependencies using 'gvt restore'.
+
+    bash -x build.sh
+    
+Once the script finishes you will see image service-center-dev.tgz in the same directory. 
+Load this image to the docker and start using.
+
+    docker run -d -p 30100:30100 developement/servicecomb/service-center

--- a/scripts/docker/build-image/build.sh
+++ b/scripts/docker/build-image/build.sh
@@ -1,0 +1,41 @@
+#! /bin/bash -e
+
+SCRIPT_DIR=$(cd $(dirname $0); pwd)
+BASE_DIR=${SCRIPT_DIR}/../../../
+
+mkdir -p $SCRIPT_DIR/service-center
+
+cd $BASE_DIR
+
+# make CGO_ENABLED=0 since busybox will not execute if it is dynamically linked
+export CGO_ENABLED=0
+
+# buils service-center
+go build -o service-center
+
+#copy service-center executable in the build-image/service-center
+cp ./service-center $SCRIPT_DIR/service-center
+
+# give permission 
+chmod 755 $SCRIPT_DIR/service-center/service-center
+
+# copy the conf folder to build-image/service-center 
+cp -r $BASE_DIR/etc/conf $SCRIPT_DIR/service-center
+
+#go to the script directory
+cd $SCRIPT_DIR
+
+# store the etcd image name  and version
+BASE_IMAGE=quay.io/coreos/etcd
+BASE_IMAGE_VERSION=v3.1.0
+
+cp Dockerfile.tmpl Dockerfile
+
+sed -i "s|{{.BASE_IMAGE}}|${BASE_IMAGE}|g" Dockerfile
+sed -i "s|{{.BASE_IMAGE_VERSION}}|${BASE_IMAGE_VERSION}|g" Dockerfile
+
+docker build -t developement/servicecomb/service-center:latest .
+docker save developement/servicecomb/service-center:latest |gzip >service-center-dev.tgz
+
+# remove the service-center directory from the build-image path
+rm -rf service-center Dockerfile 

--- a/scripts/docker/build-image/build.sh
+++ b/scripts/docker/build-image/build.sh
@@ -21,6 +21,7 @@ chmod 755 $SCRIPT_DIR/service-center/service-center
 
 # copy the conf folder to build-image/service-center 
 cp -r $BASE_DIR/etc/conf $SCRIPT_DIR/service-center
+sed -i "s|httpaddr = 127.0.0.1|httpaddr = 0.0.0.0|g" $SCRIPT_DIR/service-center/conf/app.conf
 
 #go to the script directory
 cd $SCRIPT_DIR

--- a/scripts/docker/build-image/start.sh
+++ b/scripts/docker/build-image/start.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+etcd & 
+sleep 5
+
+/root/service-center 
+


### PR DESCRIPTION
1. Run build.sh script inside scripts/docker/buid-image path.
2. It will build the service-center executable and copy the binary in the etcd base image and creates new image tar.
3. load the tar to the docker and run the image. Your service-center will be running with your new modifications if any.